### PR TITLE
feat: Added cli parser, commands and args using clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.4.3", features = ["derive"] }
 crc = "3.0.1"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,62 @@
+use std::path::PathBuf;
+
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Parser)]
+#[clap(author, version, about, long_about = None)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Encode message into a Png file
+    Encode(EncodeArgs),
+
+    /// Decode message from a Png file
+    Decode(DecodeArgs),
+
+    /// Remove message from a Png file
+    Remove(RemoveArgs),
+
+    /// Print out chunks of Png file
+    Print(PrintArgs),
+}
+
+#[derive(Args)]
+pub struct EncodeArgs {
+    pub input: PathBuf,
+
+    pub chunk_type: String,
+
+    pub message: String,
+
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub struct DecodeArgs {
+    pub input: PathBuf,
+
+    pub chunk_type: String,
+}
+
+#[derive(Args)]
+pub struct RemoveArgs {
+    pub input: PathBuf,
+
+    pub chunk_type: String,
+}
+
+#[derive(Args)]
+pub struct PrintArgs {
+    pub input: PathBuf,
+}
+
+#[test]
+fn verify_cli() {
+    use clap::CommandFactory;
+
+    Cli::command().debug_assert()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod args;
 mod chunk;
 mod chunk_type;
 mod png;


### PR DESCRIPTION
# Summary
- Added clap to parse cli arguments
- Added the necessary subcommands (`encode`, `decode`, `remove`, `print`)
- Added necessary arguments for each